### PR TITLE
`add_route` can accept also `*args`

### DIFF
--- a/src/nginx/config/builder/baseplugins.py
+++ b/src/nginx/config/builder/baseplugins.py
@@ -129,8 +129,8 @@ class Routable(Navigable):
 
     """
 
-    def add_route(self, path, **kwargs):
-        loc = Location(path, **kwargs)
+    def add_route(self, path, *args, **kwargs):
+        loc = Location(path, *args, **kwargs)
         self.add_child(loc)
         self.chobj(loc)
 


### PR DESCRIPTION
Current implementation can't handle adding extra block of options by code like example below, due missing passing `*args` inside `add_route`.
```python
from nginx.config.helpers import duplicate_options

# (...)
proxy_headers = duplicate_options('proxy_set_header', [
    ['Upgrade', '$http_upgrade'],
    ['Host', '$host']
])

server.add_route('/path', proxy_headers, proxy_pass='http://localhost/abc').end()
```