### PR TITLE
docs: fix return type at helpers.py

### DIFF
--- a/src/nginx/config/helpers.py
+++ b/src/nginx/config/helpers.py
@@ -52,7 +52,7 @@ def simple_configuration(port=8080):
     Also serves as an example of how to build configs using this module.
 
     :param int port: A port to populate the 'listen' paramter of the server block
-    :rtype str:
+    :rtype: str
     """
 
     http = Section(


### PR DESCRIPTION
Due typo it cause rendered output: `Rtype str:`